### PR TITLE
fix: 修正的iOS转换坐标枚举从-1开始

### DIFF
--- a/lib/src/ios/functions.g.dart
+++ b/lib/src/ios/functions.g.dart
@@ -20,7 +20,7 @@ Future<CLLocationCoordinate2D> AMapCoordinateConvert(CLLocationCoordinate2D coor
   }
 
   // invoke native method
-  final __result__ = await MethodChannel('me.yohom/amap_core_fluttify').invokeMethod('AMapCoordinateConvert::AMapCoordinateConvert', {"coordinate": coordinate.refId, "type": type.index});
+  final __result__ = await MethodChannel('me.yohom/amap_core_fluttify').invokeMethod('AMapCoordinateConvert::AMapCoordinateConvert', {"coordinate": coordinate.refId, "type": type.index - 1});
   
 
   // handle native call


### PR DESCRIPTION
高德 AMapFoundation/AMapUtility.h 中的定义

```Objective-C
///坐标类型枚举
typedef NS_ENUM(NSInteger, AMapCoordinateType)
{
    AMapCoordinateTypeAMap = -1,    ///<AMap
    AMapCoordinateTypeBaidu = 0,    ///<Baidu
    AMapCoordinateTypeMapBar,       ///<MapBar
    AMapCoordinateTypeMapABC,       ///<MapABC
    AMapCoordinateTypeSoSoMap,      ///<SoSoMap
    AMapCoordinateTypeAliYun,       ///<AliYun
    AMapCoordinateTypeGoogle,       ///<Google
    AMapCoordinateTypeGPS,          ///<GPS
};
```


而Dart中的定义
```dart
enum AMapCoordinateType {
  AMapCoordinateTypeAMap,
  AMapCoordinateTypeBaidu,
  AMapCoordinateTypeMapBar,
  AMapCoordinateTypeMapABC,
  AMapCoordinateTypeSoSoMap,
  AMapCoordinateTypeAliYun,
  AMapCoordinateTypeGoogle,
  AMapCoordinateTypeGPS
}
```

两者的值相差1， 导致iOS的转换坐标数值错误。 Android没有这个问题。